### PR TITLE
Add ReleaseRun to awesome-kubernetes-security

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A curated list of awesome Kubernetes security resources. Can you dig it?
 - [kubernetes-rbac-audit](https://github.com/cyberark/kubernetes-rbac-audit) - Tool for auditing RBACs in Kubernetes
 - [kubernetes-external-secrets](https://github.com/external-secrets/kubernetes-external-secrets) - Tool to get External Secrets from Hashicorp Vault and AWS SSM
 - [vault-secrets-operator](https://github.com/ricoberger/vault-secrets-operator) - An operator to create Kubernetes secrets from Vault for a secure GitOps based workflow
+- [ReleaseRun](https://releaserun.com/) - Browser-based dependency health checkers for package.json, go.mod, Cargo.toml, requirements.txt, Gemfile, pom.xml, and more. Flags EOL packages and known CVEs.
 
 ## General Resources
 


### PR DESCRIPTION
ReleaseRun is a free, browser-based toolkit for dependency health, EOL detection, and security scanning across 13+ ecosystems (npm, PyPI, Go, Rust, Maven, NuGet, Composer, and more). No install or login required.

https://releaserun.com